### PR TITLE
Fix category icon color changing bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -93,6 +93,7 @@ function validateNumberSeconds(){
 };
 
 function displayActivatedIcon() {
+  checkIcons();
   for(var i = 0; i < categoryInputs.length; i++) {
     if(categoryInputs[i].checked) {
       iconActivated[i].classList.toggle('hidden');
@@ -102,6 +103,14 @@ function displayActivatedIcon() {
   };
 };
 
+function checkIcons() {
+  for (var i = 0; i < iconDeactivated.length; i++) {
+    if(!iconDeactivated[i].classList.contains('hidden')) {
+      hide(iconDeactivated[i]);
+      display(iconActivated[i])
+    }
+  }
+}
 //refactor this to take out class list add
 function validateForm() {
   if(currentIcon === undefined) {


### PR DESCRIPTION
## Is this a fix or a feature?
Fix
## What is the change?
## What does it fix?
Previously, the category icons would switch colors if the user clicked anywhere in the category container.
Now, if the category icons change colors it is only if they are prompted too by the category button being pressed.
## Where should the reviewer start?
The displayActivatedIcons function and the checkIcons function on main.js
## How should this be tested?
clicking around the category container to see if the icons behave correctly.